### PR TITLE
Support "one-time-use" PCI devices

### DIFF
--- a/doc/dictionary.txt
+++ b/doc/dictionary.txt
@@ -13,3 +13,4 @@ imigration
 childs
 assertin
 notin
+OTU

--- a/nova/compute/resource_tracker.py
+++ b/nova/compute/resource_tracker.py
@@ -138,6 +138,21 @@ class ResourceTracker(object):
                 'not match host')
         self.service_ref = service_ref
 
+    def _invalidate_pci_in_placement_cached_rps(self, allocs):
+        """Invalidate cache for PCI-in-placement providers.
+
+        This invalidates the local cached copy of any provider for which an
+        allocation of a PCI-in-placement device exists. We do this in case the
+        reserved count has been modified externally to make sure we see it.
+        """
+        if not allocs:
+            return
+        for rp, rp_allocs in allocs.items():
+            if any(rc.startswith('CUSTOM_PCI_')
+                   for rc in rp_allocs['resources'].keys()):
+                self.reportclient.invalidate_resource_provider(rp,
+                                                               cacheonly=True)
+
     @utils.synchronized(COMPUTE_RESOURCE_SEMAPHORE, fair=True)
     def instance_claim(self, context, instance, nodename, allocations,
                        limits=None):
@@ -206,6 +221,11 @@ class ResourceTracker(object):
 
         claimed_resources = self._claim_resources(allocations)
         instance.resources = claimed_resources
+
+        # In case we have any allocations for PCI-in-placement devices, be
+        # sure to invalidate our cache of those providers before we run
+        # _update() below (which does the PCI-in-placement sync).
+        self._invalidate_pci_in_placement_cached_rps(allocations)
 
         # Mark resources in-use and update stats
         self._update_usage_from_instance(context, instance, nodename)
@@ -369,6 +389,11 @@ class ResourceTracker(object):
 
         instance.migration_context = mig_context
         instance.save()
+
+        # In case we have any allocations for PCI-in-placement devices, be
+        # sure to invalidate our cache of those providers before we run
+        # _update() below (which does the PCI-in-placement sync).
+        self._invalidate_pci_in_placement_cached_rps(allocations)
 
         # Mark the resources in-use for the resize landing on this
         # compute host:

--- a/nova/objects/pci_device.py
+++ b/nova/objects/pci_device.py
@@ -181,6 +181,8 @@ class PciDevice(base.NovaPersistentObject, base.NovaObject):
                 #       hypervisor
                 #     - "live_migratable": true/false if the device can be live
                 #       migratable
+                #     - "one_time_use": true/false if the device should only
+                #       be allocated once
                 extra_info = self.extra_info
                 data = v if isinstance(v, str) else jsonutils.dumps(v)
                 extra_info.update({k: data})
@@ -190,7 +192,7 @@ class PciDevice(base.NovaPersistentObject, base.NovaObject):
         # As in the above case, we must explicitly assign to self.extra_info
         # so that obj_what_changed detects the modification and triggers
         # a save later.
-        tags_to_clean = ["managed", "live_migratable"]
+        tags_to_clean = ["managed", "live_migratable", "one_time_use"]
         for tag in tags_to_clean:
             if tag not in dev_dict and tag in self.extra_info:
                 extra_info = self.extra_info

--- a/nova/pci/devspec.py
+++ b/nova/pci/devspec.py
@@ -17,6 +17,7 @@ import re
 import string
 import typing as ty
 
+import nova.conf
 from nova import exception
 from nova.i18n import _
 from nova import objects
@@ -35,6 +36,7 @@ ANY = '*'
 REGEX_ANY = '.*'
 
 LOG = logging.getLogger(__name__)
+CONF = nova.conf.CONF
 
 PCISpecAddressType = ty.Union[ty.Dict[str, str], str]
 
@@ -320,6 +322,15 @@ class PciDeviceSpec(PciAddressSpec):
 
         self._normalize_device_spec_tag("managed")
         self._normalize_device_spec_tag("live_migratable")
+        self._normalize_device_spec_tag("one_time_use")
+
+        if self.tags.get('one_time_use') == 'true':
+            # Validate that one_time_use=true is not set on devices where we
+            # cannot support proper reservation protection.
+            if not CONF.pci.report_in_placement:
+                raise exception.PciConfigInvalidSpec(
+                    reason=_('one_time_use=true requires '
+                             'pci.report_in_placement to be enabled'))
 
         if self._remote_managed:
             if address_obj is None:
@@ -416,7 +427,7 @@ class PciDeviceSpec(PciAddressSpec):
                 )
 
     def enhanced_pci_device_with_spec_tags(self, dev: ty.Dict[str, ty.Any]):
-        spec_tags = ["managed", "live_migratable"]
+        spec_tags = ["managed", "live_migratable", "one_time_use"]
         for tag in spec_tags:
             tag_value = self.tags.get(tag)
             if tag_value is not None:

--- a/nova/scheduler/client/report.py
+++ b/nova/scheduler/client/report.py
@@ -2389,15 +2389,18 @@ class SchedulerReportClient(object):
                 #  left a no-op for backward compatibility.
                 pass
 
-    def invalidate_resource_provider(self, name_or_uuid):
+    def invalidate_resource_provider(self, name_or_uuid, cacheonly=False):
         """Invalidate the cache for a resource provider.
 
         :param name_or_uuid: Name or UUID of the resource provider to look up.
+        :param cacheonly: Only reset the cache but do not remove the provider
+                          from the tree
         """
-        try:
-            self._provider_tree.remove(name_or_uuid)
-        except ValueError:
-            pass
+        if not cacheonly:
+            try:
+                self._provider_tree.remove(name_or_uuid)
+            except ValueError:
+                pass
         self._association_refresh_time.pop(name_or_uuid, None)
 
     def get_provider_by_name(self, context, name):

--- a/nova/tests/unit/compute/test_pci_placement_translator.py
+++ b/nova/tests/unit/compute/test_pci_placement_translator.py
@@ -270,6 +270,114 @@ class TestTranslator(test.NoDBTestCase):
             pt.data("fake-node_0000:72:00.0").uuid, pf.extra_info["rp_uuid"]
         )
 
+    def test_otu_decorates_with_trait(self):
+        pv = ppt.PlacementView(
+            "fake-node", instances_under_same_host_resize=[])
+        sd = pci_device.PciDevice(
+            address="0000:71:00.0",
+            parent_addr="0000:71:00.0",
+            dev_type=fields.PciDeviceType.STANDARD,
+            vendor_id="dead",
+            product_id="beef",
+            extra_info={'one_time_use': 'true'},
+        )
+        pf1 = pci_device.PciDevice(
+            address="0000:72:00.0",
+            parent_addr=None,
+            dev_type=fields.PciDeviceType.SRIOV_PF,
+            vendor_id="dead",
+            product_id="beef",
+            extra_info={'one_time_use': 'true'},
+        )
+        pf2 = pci_device.PciDevice(
+            address="0000:73:00.0",
+            parent_addr=None,
+            dev_type=fields.PciDeviceType.SRIOV_PF,
+            vendor_id="dead",
+            product_id="beef",
+        )
+        vf = pci_device.PciDevice(
+            address="0000:74:00.0",
+            parent_addr="0000:75:00.0",
+            dev_type=fields.PciDeviceType.SRIOV_VF,
+            vendor_id="dead",
+            product_id="beef",
+            extra_info={'one_time_use': 'true'},
+        )
+
+        pt = provider_tree.ProviderTree()
+        pt.new_root("fake-node", uuids.compute_rp)
+
+        # PF and regular devices are fine...
+        pv._add_dev(sd, {})
+        pv._add_dev(pf1, {})
+        pv._add_dev(pf2, {})
+        # ... but VFs are not allowed
+        self.assertRaisesRegex(exception.PlacementPciException,
+                               'Only.*may set one_time_use',
+                               pv._add_dev, vf, {})
+        pv.update_provider_tree(pt)
+
+        # These are both OTU, make sure we get the trait added
+        self.assertIn('HW_PCI_ONE_TIME_USE',
+                      pt.data("fake-node_0000:71:00.0").traits)
+        self.assertIn('HW_PCI_ONE_TIME_USE',
+                      pt.data("fake-node_0000:72:00.0").traits)
+        # This is not, so make sure we do not
+        self.assertNotIn('HW_PCI_ONE_TIME_USE',
+                      pt.data("fake-node_0000:73:00.0").traits)
+
+    def test_otu_reservation_workflow(self):
+        pv = ppt.PlacementView(
+            "fake-node", instances_under_same_host_resize=[])
+        sd = pci_device.PciDevice(
+            address="0000:71:00.0",
+            parent_addr="0000:71:00.0",
+            dev_type=fields.PciDeviceType.STANDARD,
+            vendor_id="dead",
+            product_id="beef",
+            extra_info={'one_time_use': 'true'},
+        )
+        pf = pci_device.PciDevice(
+            address="0000:72:00.0",
+            parent_addr=None,
+            dev_type=fields.PciDeviceType.SRIOV_PF,
+            vendor_id="dead",
+            product_id="beef",
+            extra_info={'one_time_use': 'true'},
+        )
+
+        pt = provider_tree.ProviderTree()
+        pt.new_root("fake-node", uuids.compute_rp)
+
+        pv._add_dev(sd, {})
+        pv._add_dev(pf, {})
+
+        def assert_inventory(addr, reserved):
+            self.assertEqual(
+                reserved,
+                pt.data("fake-node_0000:%i:00.0" % addr
+                        ).inventory['CUSTOM_PCI_DEAD_BEEF'].get('reserved', 0))
+
+        # Before allocation, reserved is unset
+        pv.update_provider_tree(pt)
+        assert_inventory(71, 0)
+        assert_inventory(72, 0)
+
+        # After allocation, reserved gets set to total (only for the device
+        # that is used)
+        pf.instance_uuid = uuids.instance
+        pv.update_provider_tree(pt)
+        assert_inventory(71, 0)
+        assert_inventory(72, 1)
+
+        # After deallocation, reserved is again unchanged (i.e. never
+        # decremented)
+        pf.instance_uuid = None
+        pv.update_provider_tree(pt)
+        assert_inventory(71, 0)
+        assert_inventory(72, 1)
+
     def test_update_provider_tree_for_pci_update_pools(self):
         pt = provider_tree.ProviderTree()
         pt.new_root("fake-node", uuids.compute_rp)

--- a/nova/tests/unit/compute/test_resource_tracker.py
+++ b/nova/tests/unit/compute/test_resource_tracker.py
@@ -3424,9 +3424,12 @@ class TestLiveMigration(BaseTestCase):
             mock.patch.object(objects.Instance, 'save'),
             mock.patch.object(self.rt, '_update'),
             mock.patch.object(self.rt.pci_tracker, 'claim_instance'),
-            mock.patch.object(self.rt, '_update_usage_from_migration')
+            mock.patch.object(self.rt, '_update_usage_from_migration'),
+            mock.patch.object(self.rt,
+                              '_invalidate_pci_in_placement_cached_rps')
         ) as (mock_from_instance, mock_migration_save, mock_instance_save,
-              mock_update, mock_pci_claim_instance, mock_update_usage):
+              mock_update, mock_pci_claim_instance, mock_update_usage,
+              mock_invalidate):
             claim = self.rt.live_migration_claim(ctxt, instance, _NODENAME,
                                                  migration, limits=None,
                                                  allocs=None)
@@ -3441,6 +3444,7 @@ class TestLiveMigration(BaseTestCase):
             mock_pci_claim_instance.assert_not_called()
             mock_update_usage.assert_called_with(ctxt, instance, migration,
                                                  _NODENAME)
+            mock_invalidate.assert_called()
 
 
 class TestUpdateUsageFromMigration(test.NoDBTestCase):
@@ -4349,6 +4353,26 @@ class ResourceTrackerTestCase(test.NoDBTestCase):
 
         self.assertRaises(AssertionError, _test_explict_unfair)
         self.assertRaises(AssertionError, _test_implicit_unfair)
+
+    def test_invalidate_pci_in_placement(self):
+        client = mock.MagicMock()
+        rt = resource_tracker.ResourceTracker(
+            _HOSTNAME, mock.sentinel.driver, client)
+        fake_allocs = {
+            str(uuids.compute): {
+                'resources': {
+                    'VCPU': 1,
+                },
+            },
+            str(uuids.pci): {
+                'resources': {
+                    'CUSTOM_PCI_DEAD_BEEF': 1,
+                }
+            }
+        }
+        rt._invalidate_pci_in_placement_cached_rps(fake_allocs)
+        client.invalidate_resource_provider.assert_called_once_with(
+            uuids.pci, cacheonly=True)
 
     def test_set_service_ref(self):
         rt = resource_tracker.ResourceTracker(

--- a/releasenotes/notes/one-time-use-devices-b62247dd2a4c7a15.yaml
+++ b/releasenotes/notes/one-time-use-devices-b62247dd2a4c7a15.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    The ``one_time_use`` tag was added to the PCI ``device_spec`` description,
+    which allows leaving devices in reserved state after they have been
+    assigned to an instance. This is useful for data cleaning, firmware
+    updates, and other operator-specific workflows.


### PR DESCRIPTION
This adds support for devices that will be allocated to an instance
once and left in a reserved=total state. An external workflow can
put them back into allocatable state by dropping reserved back to
zero. Note this requires PCI-in-placement tracking for the affected
devices and it is only valid for type-PCI and type-PF devices.

Related to blueprint one-time-use-devices

Depends-On: https://review.opendev.org/c/openstack/os-traits/+/944049
Change-Id: Idfe8a746a97d68cd4eae30afb7d22f4e3af80327

## Summary by Sourcery

Add support for "one-time-use" PCI devices that can be allocated once and left in a reserved state for external workflow management

New Features:
- Introduce a 'one_time_use' tag for PCI devices that allows devices to remain in a reserved state after allocation
- Add support for tracking one-time-use devices with a 'HW_PCI_ONE_TIME_USE' trait in placement

Enhancements:
- Implement reservation workflow for one-time-use PCI devices
- Add validation to ensure only type-PCI and type-PF devices can be marked as one-time-use
- Extend PCI device specification to support one-time-use configuration

Documentation:
- Add documentation for the new one-time-use PCI device feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced One-Time-Use Devices support for PCI hardware. Devices flagged for one-time use remain reserved until required maintenance tasks (e.g., secure data erasure, firmware updates) are completed, ensuring proper allocation and resource tracking.

- **Documentation**
  - Added a new administrator guide section detailing the one-time use functionality.
  - Updated the documentation glossary with the new "OTU" dictionary entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->